### PR TITLE
Fix spec output screenshot in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ others.
 After installing Ivoire, running the example above with
 ``ivoire examples/calculator_spec.py`` should produce:
 
-.. image:: https://github.com/Julian/Ivoire/raw/master/examples/img/calculator_spec_output.png
+.. image:: https://github.com/Julian/Ivoire/raw/main/examples/img/calculator_spec_output.png
     :alt: spec output
     :align: center
 


### PR DESCRIPTION
The URL was still pointing at 'master' branch but the project uses 'main' now.